### PR TITLE
Add strategy engine with scheduler and frontend triggers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,8 +6,60 @@ from starlette.staticfiles import StaticFiles
 from prometheus_client import REGISTRY, CONTENT_TYPE_LATEST, generate_latest
 from backend.app.svc import db as svc_db
 from backend.app.routers import all_routes
+from backend.app.routers import strategy
+from backend.app.middlewares import install_middlewares
 
 app = FastAPI(title="AI Trading (Windows One-Click)")
+app.include_router(strategy.router)
+install_middlewares(app)
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+import httpx, os, json
+
+scheduler = AsyncIOScheduler()
+
+@app.on_event("startup")
+async def _start_scheduler():
+    # 啟動排程器
+    if not scheduler.running:
+        scheduler.start()
+    # 從 DB 把所有有 cron 的設定掃一遍（僅示範 dca）
+    base = os.getenv("SELF_BASE_URL", "http://127.0.0.1:8000")
+    # 這裡示範單帳號；正式可掃 ai_settings 使用者清單
+    users = [os.getenv("DEFAULT_USER","sterio068@mail.com")]
+    for uid in users:
+        try:
+            r = httpx.get(f"{base}/api/ai/settings", params={"user_id":uid}, timeout=8)
+            if r.status_code==200:
+                rows = r.json().get("rows",{})
+                dca = rows.get("dca")
+                if isinstance(dca, str):
+                    try: dca=json.loads(dca)
+                    except: dca=None
+                if isinstance(dca, dict) and dca.get("cron"):
+                    cron = dca["cron"]
+                    job_id = f"dca::{uid}"
+                    if scheduler.get_job(job_id):
+                        scheduler.remove_job(job_id)
+                    # 用簡易 cron 表達式（分 時 日 月 週）
+                    scheduler.add_job(
+                        lambda: httpx.post(f"{base}/api/strategy/run", json={"kind":"dca","user_id":uid}, timeout=30),
+                        trigger="cron",
+                        id=job_id,
+                        **_parse_cron(cron)
+                    )
+        except Exception:
+            pass
+
+def _parse_cron(cron_text:str):
+    # "*/15 * * * *" → {'minute': '*/15'}
+    fields = (cron_text or "* * * * *").split()
+    out={}
+    if len(fields)>=1: out["minute"]=fields[0]
+    if len(fields)>=2: out["hour"]=fields[1]
+    if len(fields)>=3: out["day"]=fields[2]
+    if len(fields)>=4: out["month"]=fields[3]
+    if len(fields)>=5: out["day_of_week"]=fields[4]
+    return out
 
 CORS = os.getenv("CORS_ORIGINS","*")
 origins = [o.strip() for o in CORS.split(",") if o.strip()]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,13 +19,13 @@ scheduler = AsyncIOScheduler()
 
 @app.on_event("startup")
 async def _start_scheduler():
-    # 啟動排程器
+    # Start the scheduler
     if not scheduler.running:
         scheduler.start()
-    # 從 DB 把所有有 cron 的設定掃一遍（僅示範 dca）
+    # Load cron-enabled settings from DB (demo for DCA only)
     base = os.getenv("SELF_BASE_URL", "http://127.0.0.1:8000")
-    # 這裡示範單帳號；正式可掃 ai_settings 使用者清單
-    users = [os.getenv("DEFAULT_USER","sterio068@mail.com")]
+    # Demo uses a single account; production could iterate all ai_settings users
+    users = [os.getenv("DEFAULT_USER", "sterio068@mail.com")]
     for uid in users:
         try:
             r = httpx.get(f"{base}/api/ai/settings", params={"user_id":uid}, timeout=8)
@@ -40,7 +40,7 @@ async def _start_scheduler():
                     job_id = f"dca::{uid}"
                     if scheduler.get_job(job_id):
                         scheduler.remove_job(job_id)
-                    # 用簡易 cron 表達式（分 時 日 月 週）
+                    # Use simple cron expression (minute hour day month weekday)
                     scheduler.add_job(
                         lambda: httpx.post(f"{base}/api/strategy/run", json={"kind":"dca","user_id":uid}, timeout=30),
                         trigger="cron",

--- a/backend/app/middlewares.py
+++ b/backend/app/middlewares.py
@@ -1,0 +1,18 @@
+from starlette.requests import Request
+from starlette.responses import Response
+from typing import Callable, Awaitable
+import time
+import logging
+
+logger = logging.getLogger("app.mw")
+
+def install_middlewares(app):
+    @app.middleware("http")
+    async def timing_middleware(request: Request, call_next: Callable[[Request], Awaitable[Response]]):
+        t0 = time.perf_counter()
+        try:
+            resp = await call_next(request)
+            return resp
+        finally:
+            dt = (time.perf_counter() - t0) * 1000
+            logger.debug(f"[HTTP] {request.method} {request.url.path} {dt:.1f}ms")

--- a/backend/app/routers/strategy.py
+++ b/backend/app/routers/strategy.py
@@ -8,16 +8,17 @@ router = APIRouter(prefix="/api/strategy", tags=["strategy"])
 class RunReq(BaseModel):
     kind: str
     user_id: str
-    # 預留：若要一次性覆蓋設定，可附帶 params
-    params: Optional[Dict[str,Any]] = None
+    # Optional override parameters for one-off execution
+    params: Optional[Dict[str, Any]] = None
 
 @router.post("/run")
 def run_strategy(req: RunReq):
+    """Trigger a trading strategy for the given user."""
     try:
-        if req.kind.lower()=="dca":
+        if req.kind.lower() == "dca":
             out = run_dca(req.user_id)
-            return {"ok": True, "kind":"dca", "result": out}
-        # 預留：breakout/grid
-        return {"ok": False, "error":"unsupported_kind"}
+            return {"ok": True, "kind": "dca", "result": out}
+        # Placeholder for future strategies (breakout, grid, etc.)
+        return {"ok": False, "error": "unsupported_kind"}
     except Exception as e:
         return {"ok": False, "error": str(e)}

--- a/backend/app/routers/strategy.py
+++ b/backend/app/routers/strategy.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Body
+from pydantic import BaseModel
+from typing import Optional, Any, Dict
+from backend.app.services.strategy_engine import run_dca
+
+router = APIRouter(prefix="/api/strategy", tags=["strategy"])
+
+class RunReq(BaseModel):
+    kind: str
+    user_id: str
+    # 預留：若要一次性覆蓋設定，可附帶 params
+    params: Optional[Dict[str,Any]] = None
+
+@router.post("/run")
+def run_strategy(req: RunReq):
+    try:
+        if req.kind.lower()=="dca":
+            out = run_dca(req.user_id)
+            return {"ok": True, "kind":"dca", "result": out}
+        # 預留：breakout/grid
+        return {"ok": False, "error":"unsupported_kind"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}

--- a/backend/app/services/strategy_engine.py
+++ b/backend/app/services/strategy_engine.py
@@ -29,7 +29,7 @@ def _okx_headers(c:httpx.Client, method:str, path:str, body:str="")->Dict[str,st
     return h
 
 def _place_order_spot_market_quote(instId:str, quote_amount:float, side:str="buy")->Dict[str,Any]:
-    """以 USDT 名目下 **SPOT 市價單**（OKX 需使用 tgtCcy=quote_ccy）"""
+    """Place a spot market order using quote currency as notional (OKX requires tgtCcy=quote_ccy)."""
     body = {
         "instId": instId,
         "tdMode": "cash",
@@ -45,7 +45,7 @@ def _place_order_spot_market_quote(instId:str, quote_amount:float, side:str="buy
         return {"status": r.status_code, "json": r.json()}
 
 def _place_order_swap_market(instId:str, sz:float, side:str="buy", tdMode:str="cross")->Dict[str,Any]:
-    """以 **張數** 下 **SWAP 市價單**"""
+    """Place a swap market order using contract size."""
     body = {
         "instId": instId,
         "tdMode": tdMode,         # "cross" 或 "isolated"
@@ -60,10 +60,10 @@ def _place_order_swap_market(instId:str, sz:float, side:str="buy", tdMode:str="c
         r = c.post("/api/v5/trade/order", headers=h, content=j)
         return {"status": r.status_code, "json": r.json()}
 
-# --- 讀 instrument（拿到 minNotional、ctVal/tick 等） ---
+# --- Fetch instrument details (minNotional, ctVal, tick, etc.) ---
 def get_instrument(inst:str, instType:str)->Dict[str,Any]:
     with httpx.Client(base_url=os.getenv("API_BASE", ""), timeout=15) as c:
-        # 優先走本服務封裝的 /api/okx/instrument（含 minNotional & ui_hint）
+        # Prefer service wrapper /api/okx/instrument first (includes minNotional & ui_hint)
         base = os.getenv("SELF_BASE_URL", "http://127.0.0.1:8000")
         try:
             r = httpx.get(f"{base}/api/okx/instrument", params={"inst":inst,"instType":instType}, timeout=12)
@@ -71,7 +71,7 @@ def get_instrument(inst:str, instType:str)->Dict[str,Any]:
                 return r.json()
         except Exception:
             pass
-    # 後備直打 OKX (只拿必要欄位)
+    # Fallback to direct OKX call (only essential fields)
     with httpx.Client(base_url=OKX_BASE, timeout=15) as c:
         r = c.get("/api/v5/public/instruments", params={"instType":instType, "uly":inst if instType in ("SWAP","FUTURES") else None, "instId": inst})
         data = r.json().get("data",[]) or [{}]
@@ -90,7 +90,7 @@ def get_instrument(inst:str, instType:str)->Dict[str,Any]:
             "price": {"last": float(last or 0)}
         }
 
-# --- 讀風控 ---
+# --- Fetch risk control limits ---
 def get_risk_limits(user_id:str)->Dict[str,Any]:
     base = os.getenv("SELF_BASE_URL", "http://127.0.0.1:8000")
     try:
@@ -111,21 +111,21 @@ def _within_window(window_str:str, now_ts:Optional[float]=None)->bool:
     except Exception:
         return True
 
-# --- 當日 PnL（best-effort） ---
+# --- Daily PnL (best effort) ---
 def _get_daily_pnl()->Tuple[float,float]:
-    """回傳 (realized_pnl_today, unrealized_pnl_now)。抓不到就回 (0,0)。"""
+    """Return `(realized_pnl_today, unrealized_pnl_now)`; fallback to `(0, 0)` on failure."""
     realized = 0.0
     unreal   = 0.0
     try:
         with httpx.Client(base_url=OKX_BASE, timeout=20) as c:
-            # 取 today 的部分成交（realized 粗估）
+            # Fetch today's fills (approximate realized)
             h = _okx_headers(c, "GET", "/api/v5/trade/fills-history")
             r = c.get("/api/v5/trade/fills-history", headers=h, params={"limit":"100"})
             if r.status_code==200:
                 for it in r.json().get("data",[]):
-                    # OKX 不直接回 realized pnl，這裡以 taker 費用+價差估（保守：不扣正負，記為 0）
+                    # OKX does not return realized PnL; estimate via taker fee and price difference (conservative)
                     pass
-            # 取未平倉的浮盈虧（unrealized）
+            # Fetch unrealized PnL from open positions
             h2 = _okx_headers(c, "GET", "/api/v5/account/positions")
             r2 = c.get("/api/v5/account/positions", headers=h2)
             if r2.status_code==200:
@@ -136,13 +136,13 @@ def _get_daily_pnl()->Tuple[float,float]:
         return 0.0, 0.0
     return realized, unreal
 
-# --- 讀 AI 設定 ---
+# --- Fetch AI settings ---
 def get_ai_settings(user_id:str)->Dict[str,Any]:
     base = os.getenv("SELF_BASE_URL", "http://127.0.0.1:8000")
     r = httpx.get(f"{base}/api/ai/settings", params={"user_id":user_id}, timeout=8)
     if r.status_code==200:
         rows = r.json().get("rows",{})
-        # 可能是字串，嘗試 json 轉 dict
+        # Value may be string; try parsing JSON
         out={}
         for k,v in rows.items():
             if isinstance(v,str):
@@ -153,15 +153,16 @@ def get_ai_settings(user_id:str)->Dict[str,Any]:
         return out
     return {}
 
-# --- 主策略：DCA（SPOT: 用 budget 名目；SWAP: 用 sz 張） ---
+# --- Main strategy: DCA (SPOT uses budget; SWAP uses contract size) ---
 def run_dca(user_id:str)->Dict[str,Any]:
+    """Execute the DCA strategy for the given user."""
     ai = get_ai_settings(user_id)
     dca = ai.get("dca") or {}
     symbols = dca.get("symbols") or []
     instType = (dca.get("instType") or "SPOT").upper()
     result = {"ok": False, "orders": [], "reason": ""}
 
-    # 風控/時窗/日內虧損
+    # Risk checks: time window and daily loss
     rk = get_risk_limits(user_id)
     if not _within_window(rk.get("window","00:00-23:59")):
         result["reason"]="outside_window"
@@ -179,7 +180,7 @@ def run_dca(user_id:str)->Dict[str,Any]:
         per = budget / max(1,len(symbols))
         for s in symbols:
             info = get_instrument(s, "SPOT")
-            # 安全下單：若 minNotional 存在，至少覆蓋 minNotional
+            # Safe order: respect minNotional if provided
             minNotional = float(info.get("rules",{}).get("minNotional", 0) or 0)
             quote = max(per, minNotional or 1.0)
             o = _place_order_spot_market_quote(s, quote, side="buy")
@@ -188,7 +189,7 @@ def run_dca(user_id:str)->Dict[str,Any]:
         return result
 
     elif instType in ("SWAP","FUTURES"):
-        # SWAP：以「張」下單
+        # SWAP: place orders by contract size
         sz = float(dca.get("sz", 0) or 0)
         if sz <= 0 or not symbols:
             result["reason"]="missing_sz_or_symbols"
@@ -202,4 +203,4 @@ def run_dca(user_id:str)->Dict[str,Any]:
     result["reason"]="unsupported_instType"
     return result
 
-#（之後可擴：run_breakout/run_grid）
+# (future extensions: run_breakout/run_grid)

--- a/frontend/src/pages/SimLab.tsx
+++ b/frontend/src/pages/SimLab.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { toast } from "react-hot-toast";
+
+export default function SimLab() {
+  async function runStrategy(kind: 'dca'|'breakout'|'grid') {
+    try{
+      const user_id = localStorage.getItem('user_id') || 'sterio068@mail.com';
+      const r = await fetch('/api/strategy/run', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({kind, user_id})
+      });
+      const j = await r.json();
+      if(j.ok || (j.result && j.result.ok)) toast.success(`已執行 ${kind}`);
+      else toast(`${kind}：${j.error||'已返回'}`, {icon:'ℹ️'});
+    }catch(e:any){
+      toast.error('執行失敗：'+e.message);
+    }
+  }
+
+  return (
+    <>
+      {/* 既有內容 ... */}
+      <div className='mt-6 flex gap-2'>
+        <button className='btn btn-primary' onClick={()=>runStrategy('dca')}>立即執行 DCA</button>
+        <button className='btn' onClick={()=>runStrategy('breakout')}>立即執行 Breakout</button>
+        <button className='btn' onClick={()=>runStrategy('grid')}>立即執行 Grid</button>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/StrategySettings.tsx
+++ b/frontend/src/pages/StrategySettings.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { toast } from "react-hot-toast";
+
+export default function StrategySettings() {
+  async function runStrategy(kind: 'dca'|'breakout'|'grid') {
+    try{
+      const user_id = localStorage.getItem('user_id') || 'sterio068@mail.com';
+      const r = await fetch('/api/strategy/run', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({kind, user_id})
+      });
+      const j = await r.json();
+      if(j.ok || (j.result && j.result.ok)) toast.success(`已執行 ${kind}`);
+      else toast(`${kind}：${j.error||'已返回'}`, {icon:'ℹ️'});
+    }catch(e:any){
+      toast.error('執行失敗：'+e.message);
+    }
+  }
+
+  return (
+    <>
+      {/* 既有設定表單 ... */}
+      <div className='mt-6 flex gap-2'>
+        <button className='btn btn-primary' onClick={()=>runStrategy('dca')}>立即執行 DCA</button>
+        <button className='btn' onClick={()=>runStrategy('breakout')}>立即執行 Breakout</button>
+        <button className='btn' onClick={()=>runStrategy('grid')}>立即執行 Grid</button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- decouple metrics middleware from all_routes and move to reusable install_middlewares
- add strategy engine with DCA support and scheduling via APScheduler
- expose `/api/strategy/run` router and add UI buttons to trigger strategies

## Testing
- `pip install httpx apscheduler`
- `python -m py_compile backend/app/main.py backend/app/routers/all_routes.py backend/app/middlewares.py backend/app/services/strategy_engine.py backend/app/routers/strategy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c59d3366c8832d98adea1af32c213d